### PR TITLE
Fix spelling error in man

### DIFF
--- a/src/sasutil.c
+++ b/src/sasutil.c
@@ -71,7 +71,7 @@
  * <b>reset</b>
  *     Resets the anchor semaphore (used to access the control shared memory
  *     segment), the allocated segments and all internal locks. This command
- *     is usefull to reset the SPHDE state after an process finished with
+ *     is useful to reset the SPHDE state after an process finished with
  *     unexpected error (like a SEGFAULT).
  * </pre>
  *


### PR DESCRIPTION
Sorry to bother with such a small one :) but this was reported by debian lintian