### PR TITLE
Generate man pages with aminclude

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,5 +3,9 @@
 ACLOCAL_AMFLAGS = -I m4
 
 include $(top_srcdir)/aminclude.am
+man1_MANS = doc/man/man1/sasutil.1
+$(man1_MANS): doc
+EXTRA_DIST = $(man1_MANS)
+MOSTLYCLEANFILES = $(DX_CLEANFILES)
 
 SUBDIRS = src


### PR DESCRIPTION
I needed a man page and it seems that it needed a few things to get them generated though
the doc infrastructure is in place.
aminclude.am provides all that is needed to generate documentation but it
needs to be added to Makefile.am
This is a bare minimum : it may requires also : 
- to get rid of doc/Makefile.* (I guessed these was the previouse way of generating the documentation)
- update aminclude.am so that the cleanup of doxygen generated files gets properly done