### PR TITLE
Doxygen fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,11 +16,6 @@ $(man1_MANS): doc
 
 MOSTLYCLEANFILES = $(DX_CLEANFILES)
 
-distclean-local: distclean-local-doc
-.PHONY: distclean-local-doc
-distclean-local-doc:
-	-rm -rf doc/latex doc/doxygen_sqlite3.db
-
 ChangeLog.md:
 	$(am__cd) $(top_srcdir) && ./generate-changelog.sh > \
 	  $(abs_top_builddir)/$@

--- a/Makefile.in
+++ b/Makefile.in
@@ -379,11 +379,12 @@ top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I m4
 @DX_COND_doc_TRUE@@DX_COND_html_TRUE@DX_CLEAN_HTML = @DX_DOCDIR@/html
 @DX_COND_doc_TRUE@@DX_COND_man_TRUE@DX_CLEAN_MAN = @DX_DOCDIR@/man
-@DX_COND_doc_TRUE@@DX_COND_pdf_TRUE@DX_CLEAN_PDF = @DX_DOCDIR@/@PACKAGE@.pdf
+@DX_COND_doc_TRUE@@DX_COND_pdf_TRUE@DX_CLEAN_PDF = @DX_DOCDIR@/@PACKAGE@.pdf @DX_DOCDIR@/latex
 @DX_COND_doc_TRUE@@DX_COND_pdf_TRUE@DX_PDF_GOAL = pdf
 @DX_COND_doc_TRUE@DX_CLEANFILES = \
 @DX_COND_doc_TRUE@    @DX_DOCDIR@/@PACKAGE@.tag \
-@DX_COND_doc_TRUE@    -r \
+@DX_COND_doc_TRUE@    -rf \
+@DX_COND_doc_TRUE@    @DX_DOCDIR@/doxygen_sqlite3.db \
 @DX_COND_doc_TRUE@    $(DX_CLEAN_HTML) \
 @DX_COND_doc_TRUE@    $(DX_CLEAN_MAN) \
 @DX_COND_doc_TRUE@    $(DX_CLEAN_PDF)
@@ -861,7 +862,7 @@ distclean: distclean-recursive
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 	-rm -f Makefile
 distclean-am: clean-am distclean-generic distclean-hdr \
-	distclean-libtool distclean-local distclean-tags
+	distclean-libtool distclean-tags
 
 dvi: dvi-recursive
 
@@ -934,19 +935,18 @@ uninstall-man: uninstall-man1
 	clean-libtool cscope cscopelist-am ctags ctags-am dist \
 	dist-all dist-bzip2 dist-gzip dist-lzip dist-shar dist-tarZ \
 	dist-xz dist-zip distcheck distclean distclean-generic \
-	distclean-hdr distclean-libtool distclean-local distclean-tags \
-	distcleancheck distdir distuninstallcheck dvi dvi-am html \
-	html-am info info-am install install-am install-data \
-	install-data-am install-dist_docDATA install-dvi \
-	install-dvi-am install-exec install-exec-am install-html \
-	install-html-am install-info install-info-am install-man \
-	install-man1 install-pdf install-pdf-am install-ps \
-	install-ps-am install-strip installcheck installcheck-am \
-	installdirs installdirs-am maintainer-clean \
-	maintainer-clean-generic mostlyclean mostlyclean-generic \
-	mostlyclean-libtool pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-dist_docDATA uninstall-man \
-	uninstall-man1
+	distclean-hdr distclean-libtool distclean-tags distcleancheck \
+	distdir distuninstallcheck dvi dvi-am html html-am info \
+	info-am install install-am install-data install-data-am \
+	install-dist_docDATA install-dvi install-dvi-am install-exec \
+	install-exec-am install-html install-html-am install-info \
+	install-info-am install-man install-man1 install-pdf \
+	install-pdf-am install-ps install-ps-am install-strip \
+	installcheck installcheck-am installdirs installdirs-am \
+	maintainer-clean maintainer-clean-generic mostlyclean \
+	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
+	tags tags-am uninstall uninstall-am uninstall-dist_docDATA \
+	uninstall-man uninstall-man1
 
 
 @DX_COND_doc_TRUE@@DX_COND_pdf_TRUE@pdf: @DX_DOCDIR@/@PACKAGE@.pdf
@@ -980,11 +980,6 @@ uninstall-man: uninstall-man1
 @DX_COND_doc_TRUE@	done
 
 $(man1_MANS): doc
-
-distclean-local: distclean-local-doc
-.PHONY: distclean-local-doc
-distclean-local-doc:
-	-rm -rf doc/latex doc/doxygen_sqlite3.db
 
 ChangeLog.md:
 	$(am__cd) $(top_srcdir) && ./generate-changelog.sh > \

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -168,7 +168,9 @@ DX_ARG_ABLE(pdf, [generate doxygen PDF documentation],
             [DX_CLEAR_DEPEND(doc, 1)],
             [DX_REQUIRE_PROG([DX_PDFLATEX], pdflatex)
              DX_REQUIRE_PROG([DX_MAKEINDEX], makeindex)
-             DX_REQUIRE_PROG([DX_EGREP], egrep)])
+             DX_REQUIRE_PROG([DX_EGREP], egrep)],
+            [DX_ENV_APPEND(GENERATE_PDF, YES)],
+            [DX_ENV_APPEND(GENERATE_PDF, NO)])
 
 #For debugging:
 #echo DX_FLAG_doc=$DX_FLAG_doc

--- a/aminclude.am
+++ b/aminclude.am
@@ -36,7 +36,7 @@ endif DX_COND_man
 
 if DX_COND_pdf
 
-DX_CLEAN_PDF = @DX_DOCDIR@/@PACKAGE@.pdf
+DX_CLEAN_PDF = @DX_DOCDIR@/@PACKAGE@.pdf @DX_DOCDIR@/latex
 
 DX_PDF_GOAL = pdf
 
@@ -74,7 +74,8 @@ doc: doc-run $(DX_PDF_GOAL)
 
 DX_CLEANFILES = \
     @DX_DOCDIR@/@PACKAGE@.tag \
-    -r \
+    -rf \
+    @DX_DOCDIR@/doxygen_sqlite3.db \
     $(DX_CLEAN_HTML) \
     $(DX_CLEAN_MAN) \
     $(DX_CLEAN_PDF)

--- a/configure
+++ b/configure
@@ -17619,6 +17619,7 @@ else
   DX_COND_pdf_FALSE=
 fi
 
+    DX_ENV="$DX_ENV GENERATE_PDF='YES'"
 
     :
 else
@@ -17630,6 +17631,7 @@ else
   DX_COND_pdf_FALSE=
 fi
 
+    DX_ENV="$DX_ENV GENERATE_PDF='NO'"
 
     :
 fi

--- a/doc/libsphde-doxygen-sasutil.doxy
+++ b/doc/libsphde-doxygen-sasutil.doxy
@@ -651,3 +651,11 @@ EXPAND_AS_DEFINED      =
 
 SKIP_FUNCTION_MACROS   = YES
 
+#---------------------------------------------------------------------------
+# configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+
+# If the GENERATE_LATEX tag is set to YES (the default) Doxygen will
+# generate Latex output.
+
+GENERATE_LATEX         = $(GENERATE_PDF)


### PR DESCRIPTION
Some crusty autotooling was causing doxygen to always attempt creating a pdf, regardless of the --enable-doxygen-pdf configure option, or whether pdflatex was even installed.