### PR TITLE
Fixing dist target for the doc/ directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ SUBDIRS = src
 DIST_SUBDIRS = examples $(SUBDIRS)
 
 man1_MANS = doc/man/man1/sasutil.1
-EXTRA_DIST = $(man1_MANS) doc
+EXTRA_DIST = $(DX_CONFIG) doc/sphmaindox.h
 
 $(man1_MANS): doc
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,12 +9,15 @@ dist_doc_DATA = COPYING ChangeLog.md
 SUBDIRS = src
 DIST_SUBDIRS = examples $(SUBDIRS)
 
-man1_MANS = doc/man/man1/sasutil.1
 EXTRA_DIST = $(DX_CONFIG) doc/sphmaindox.h
+
+if DX_COND_doc
+man1_MANS = doc/man/man1/sasutil.1
 
 $(man1_MANS): doc
 
 MOSTLYCLEANFILES = $(DX_CLEANFILES)
+endif DX_COND_doc
 
 ChangeLog.md:
 	$(am__cd) $(top_srcdir) && ./generate-changelog.sh > \


### PR DESCRIPTION
Buggy behaviour was that doc/ directory was entirely copied in the dist tarball with
the generated documentation (html, man) ; see #12 
Now doc/ in dist tarball will only include .doxy and .h files that are
originally in the doc/ source.

Signed-off-by: Frederic Bonnard <frediz@linux.vnet.ibm.com>