### PR TITLE
Fix doxygen warnings

### DIFF
--- a/doc/libsphde-doxygen-sasutil.doxy
+++ b/doc/libsphde-doxygen-sasutil.doxy
@@ -273,12 +273,6 @@ MAX_INITIALIZER_LINES  = 30
 
 SHOW_USED_FILES        = YES
 
-# If the sources in your project are distributed over multiple directories
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
-
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page.
 # This will remove the Files entry from the Quick Index and from the
 # Folder Tree View (if specified). The default is YES.

--- a/doc/libsphde-doxygen-sph.doxy
+++ b/doc/libsphde-doxygen-sph.doxy
@@ -273,22 +273,6 @@ SUBGROUPING            = YES
 
 TYPEDEF_HIDES_STRUCT   = NO
 
-# The SYMBOL_CACHE_SIZE determines the size of the internal cache use to
-# determine which symbols to keep in memory and which to flush to disk.
-# When the cache is full, less often used symbols will be written to disk.
-# For small to medium size projects (<1000 input files) the default value is
-# probably good enough. For larger projects a too small cache size can cause
-# doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
-# If the system has enough physical memory increasing the cache will improve the
-# performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
-# memory usage. The cache size is given by this formula:
-# 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
-# corresponding to a cache size of 2^16 = 65536 symbols
-
-SYMBOL_CACHE_SIZE      = 0
-
 # NOTE: This is taken from the srcdir variable, which "make distcheck" plays 
 # with. You may need to add subdirectory(s) here, depending on your directory 
 # structure. But you almost certainly want the SRCDIR itself to be stripped. 
@@ -471,12 +455,6 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 
 SHOW_USED_FILES        = YES
-
-# If the sources in your project are distributed over multiple directories
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page.
 # This will remove the Files entry from the Quick Index and from the
@@ -829,12 +807,6 @@ HTML_STYLESHEET        =
 
 HTML_TIMESTAMP         = YES
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
-# files or namespaces will be aligned in HTML using tables. If set to
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = YES
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded. For this to work a browser that supports
@@ -982,11 +954,6 @@ ENUM_VALUES_PER_LINE   = 4
 # Windows users are probably better off using the HTML help feature.
 
 GENERATE_TREEVIEW      = NO
-
-# By enabling USE_INLINE_TREES, doxygen will generate the Groups, Directories,
-# and Class Hierarchy pages using a tree view instead of an ordered list.
-
-USE_INLINE_TREES       = NO
 
 # If the treeview is enabled (see GENERATE_TREEVIEW) then this tag can be
 # used to set the initial width (in pixels) of the frame in which the tree
@@ -1287,17 +1254,6 @@ HIDE_UNDOC_RELATIONS   = YES
 # have no effect if this option is set to NO (the default)
 
 HAVE_DOT               = NO
-
-# By default doxygen will write a font called FreeSans.ttf to the output
-# directory and reference it in all dot files that doxygen generates. This
-# font does not include all possible unicode characters however, so when you need
-# these (or just want a differently looking font) you can specify the font name
-# using DOT_FONTNAME. You need need to make sure dot is able to find the font,
-# which can be done by putting it in a standard location or by setting the
-# DOTFONTPATH environment variable or by setting DOT_FONTPATH to the directory
-# containing the font.
-
-DOT_FONTNAME           = FreeSans
 
 # The DOT_FONTSIZE tag can be used to set the size of the font of dot graphs.
 # The default size is 10pt.

--- a/src/sasindexkey.h
+++ b/src/sasindexkey.h
@@ -177,6 +177,7 @@ SASIndexKeyInitRef (SASIndexKey_t * dest, void *value)
 /** \brief Union of value types and key machine integer types.
 */
 typedef union {
+    /*! data area containing the binary key. */
 #ifdef __WORDSIZE_64
 	machine_uint_t	key_element;
 #else
@@ -190,8 +191,11 @@ typedef union {
 #endif
     } key_element;
 #endif
+    /*! key element type as an unsigned 64-bit integer. */
     unsigned long long	uint64_key;
+    /*! key element type as a signed 64-bit integer. */
     long long			int64_key;
+    /*! key element type as a double. */
     double				double_key;
 	} sasindexkeymap_t;
 

--- a/src/sphtimer.h
+++ b/src/sphtimer.h
@@ -53,6 +53,7 @@
  * \endcode
  */
 
+/** \brief ignore this macro behind the curtain. **/
 #ifdef __cplusplus
 #define __C__ "C"
 #else
@@ -116,6 +117,7 @@ typedef unsigned long long int sphtimer_t;
   } while (0)
 #else
 #include <time.h>
+/** \brief Read the Time Base value. **/
 #define __TIME_BASE(__time_v)				\
   do {							\
     struct timespec __ts;					\


### PR DESCRIPTION
Signed-off-by: Rajalakshmi Srinivasaraghavan <raji@linux.vnet.ibm.com>

        * doc/libsphde-doxygen-sasutil.doxy: Remove obsolete tags.
        * doc/libsphde-doxygen-sph.doxy: Likewise.
        * src/sasindexkey.h: Document two macros.
        * src/sphtimer.h: Document sasindexkeymap_t members.