### PR TITLE
Fix sasutil warning

### DIFF
--- a/src/sasutil.c
+++ b/src/sasutil.c
@@ -634,7 +634,7 @@ main(int argc, char *argv[])
       exit(EXIT_SUCCESS);
     }
   }
-  sasutil_usage("invalid command: %s\n", cmd);
+  sasutil_help("invalid command: %s\n", cmd);
 
 
   return 0;


### PR DESCRIPTION
Signed-off-by:  Rajalakshmi Srinivasaraghavan  <raji@linux.vnet.ibm.com>

	* src/sasutil.c: Use correct function to give error.