### PR TITLE
Add missing closing bracket

### DIFF
--- a/src/sasatom_i386.h
+++ b/src/sasatom_i386.h
@@ -25,6 +25,7 @@ __arch_pause (void)
    :
    : "memory"
   );
+}
 
 static inline void *
 __arch_fetch_and_add_ptr (void**pointer, long int delta)


### PR DESCRIPTION
On i386, compilation fails because of this.

Signed-off-by: Frederic Bonnard <frediz@linux.vnet.ibm.com>