### PR TITLE
Add check for static libc in configure

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -24,6 +24,9 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
+/* Define to 1 if you have the `c' library (-lc). */
+#undef HAVE_LIBC
+
 /* Define to 1 if your system has a GNU libc compatible `malloc' function, and
    to 0 otherwise. */
 #undef HAVE_MALLOC

--- a/configure
+++ b/configure
@@ -16814,6 +16814,60 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+# Check for static libc
+if test "$enable_static" = yes ; then
+SAVE_LDFLAGS="$LDFLAGS"
+LDFLAGS="-static $LDFLAGS"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for printf in -lc" >&5
+$as_echo_n "checking for printf in -lc... " >&6; }
+if ${ac_cv_lib_c_printf+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lc  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char printf ();
+int
+main ()
+{
+return printf ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_c_printf=yes
+else
+  ac_cv_lib_c_printf=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_printf" >&5
+$as_echo "$ac_cv_lib_c_printf" >&6; }
+if test "x$ac_cv_lib_c_printf" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBC 1
+_ACEOF
+
+  LIBS="-lc $LIBS"
+
+else
+  as_fn_error $? "*** No static libc found. Try to install glibc-static or libc6-dev." "$LINENO" 5
+fi
+
+LDFLAGS="$SAVE_LDFLAGS"
+fi
+
 # Doxygen support
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,15 @@ AC_CHECK_FUNCS([clock_gettime ftruncate getcwd getpagesize gettimeofday memset m
 # Pthread check (on m4/acx_pthread.m4)
 ACX_PTHREAD
 
+# Check for static libc
+if test "$enable_static" = yes ; then
+SAVE_LDFLAGS="$LDFLAGS"
+LDFLAGS="-static $LDFLAGS"
+AC_CHECK_LIB([c], [printf], [],
+             AC_MSG_ERROR([*** No static libc found. Try to install glibc-static or libc6-dev.]))
+LDFLAGS="$SAVE_LDFLAGS"
+fi
+
 # Doxygen support
 DX_HTML_FEATURE(ON)
 DX_MAN_FEATURE(ON)


### PR DESCRIPTION
Signed-off-by:  Rajalakshmi Srinivasaraghavan  <raji@linux.vnet.ibm.com>

	* configure.ac: Add check for static libc.
	* configure: Regenerate.
	* config.h.in: Likewise.