### PR TITLE
Use atomic builtins

### DIFF
--- a/src/bitv.c
+++ b/src/bitv.c
@@ -14,6 +14,7 @@
 //#define PRINT_DEBUG 1
 #include <bitv_priv.h>
 #include <stdio.h>
+#include "sasatom.h"
 
 void
 bitv_init (bitv_cb_t * cb, size_t unit)
@@ -166,7 +167,7 @@ bitv_alloc_marked (bitv_cb_t * cb, bitv_word * bvec, bitv_word * endvec,
 		{		/* cur_msk was still valid and update successful */
 		  bitv_word end_mrk, chk_mrk __attribute__((unused));
 		  end_mrk = bitv_mask_to_end_mrk (req_msk);
-		  chk_mrk = __sync_fetch_and_or (endvec, end_mrk);
+		  chk_mrk = fetch_and_or_long (endvec, end_mrk);
 #ifdef PRINT_DEBUG
 		  printf ("i=%ld, req_msk=%lx, end_mrk=%lx\n",
 			  i, req_msk, end_mrk);
@@ -353,7 +354,7 @@ bitv_aligned_alloc_marked (bitv_cb_t * cb, bitv_word * bvec,
 		{		/* cur_msk was still valid and update successful */
 		  bitv_word end_mrk, chk_mrk __attribute__((unused));
 		  end_mrk = bitv_mask_to_end_mrk (req_msk);
-		  chk_mrk = __sync_fetch_and_or (endvec, end_mrk);
+		  chk_mrk = fetch_and_or_long (endvec, end_mrk);
 #ifdef PRINT_DEBUG
 		  printf ("i=%ld, req_msk=%lx, end_mrk=%lx\n",
 			  i, req_msk, end_mrk);
@@ -410,7 +411,7 @@ bitv_dealloc_internal (bitv_word * bvec, bitv_word offset, size_t alloc_units)
     return -1;
 
   req_msk >>= offset;
-  prv_msk = __sync_fetch_and_or (bvec, req_msk);
+  prv_msk = fetch_and_or_long (bvec, req_msk);
   /* Insure that we are deallocating units that were previously
      allocated. If so the logical and of the original unit mask
      and the requested mask should be 0s. */
@@ -485,7 +486,7 @@ bitv_free_marked (bitv_cb_t * cb, bitv_word * bvec, bitv_word * endvec,
       alloc_units = units + 1;
       endmrk = bit_zero >> (offset + units);
 
-      chkmsk = __sync_fetch_and_and (endvec, ~endmrk);
+      chkmsk = fetch_and_and_long (endvec, ~endmrk);
 
 #ifdef PRINT_DEBUG
       printf (" units=%ld, endmrk=%lx, chkmsk=%lx\n", units, endmrk, chkmsk);

--- a/src/sasatom.h
+++ b/src/sasatom.h
@@ -102,7 +102,7 @@ static inline long int
 fetch_and_and(unsigned int *pointer, int delta)
 {
 #if GCC_VERSION >= 40700
-  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQUIRE);
+  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_and(pointer, delta);
 #endif
@@ -120,7 +120,7 @@ static inline long int
 fetch_and_and_long(unsigned long *pointer, long int delta)
 {
 #if GCC_VERSION >= 40700
-  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQUIRE);
+  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_and(pointer, delta);
 #endif
@@ -138,7 +138,7 @@ static inline long int
 fetch_and_or(unsigned int *pointer, int delta)
 {
 #if GCC_VERSION >= 40700
-  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQUIRE);
+  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_or(pointer, delta);
 #endif
@@ -156,7 +156,7 @@ static inline long int
 fetch_and_or_long(unsigned long *pointer, long int delta)
 {
 #if GCC_VERSION >= 40700
-  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQUIRE);
+  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQ_REL);
 #else
   return __sync_fetch_and_or(pointer, delta);
 #endif

--- a/src/sasatom.h
+++ b/src/sasatom.h
@@ -40,6 +40,8 @@ typedef void*         sas_lock_ptr_t;
 #include "sasatom_generic.h"
 #endif
 
+#define GCC_VERSION \
+        (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 /*!
  * Memory barrier for store operations.
  */
@@ -88,6 +90,77 @@ fetch_and_add(void *pointer, long int delta)
   return __arch_fetch_and_add(pointer, delta);
 }
 
+/*!
+ * Atomic fetch and and operation on memory \a pointer of int type.
+ *
+ * Performs the atomic operation:
+ * { tmp = *pointer; *pointer = tmp & delta; return *pointer }
+ *
+ * Returns \a *pointer before update.
+ */
+static inline long int
+fetch_and_and(unsigned int *pointer, int delta)
+{
+#if GCC_VERSION >= 40700
+  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQUIRE);
+#else
+  return __sync_fetch_and_and(pointer, delta);
+#endif
+}
+
+/*!
+ * Atomic fetch and and operation on memory \a pointer of long type.
+ *
+ * Performs the atomic operation:
+ * { tmp = *pointer; *pointer = tmp & delta; return *pointer }
+ *
+ * Returns \a *pointer before update.
+ */
+static inline long int
+fetch_and_and_long(unsigned long *pointer, long int delta)
+{
+#if GCC_VERSION >= 40700
+  return __atomic_fetch_and(pointer, delta, __ATOMIC_ACQUIRE);
+#else
+  return __sync_fetch_and_and(pointer, delta);
+#endif
+}
+
+/*!
+ * Atomic fetch and or operation on memory \a pointer of int type.
+ *
+ * Performs the atomic operation:
+ * { tmp = *pointer; *pointer = tmp | delta; return *pointer }
+ *
+ * Returns \a *pointer before update.
+ */
+static inline long int
+fetch_and_or(unsigned int *pointer, int delta)
+{
+#if GCC_VERSION >= 40700
+  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQUIRE);
+#else
+  return __sync_fetch_and_or(pointer, delta);
+#endif
+}
+
+/*!
+ * Atomic fetch and or operation on memory \a pointer of long type.
+ *
+ * Performs the atomic operation:
+ * { tmp = *pointer; *pointer = tmp | delta; return *pointer }
+ *
+ * Returns \a *pointer before update.
+ */
+static inline long int
+fetch_and_or_long(unsigned long *pointer, long int delta)
+{
+#if GCC_VERSION >= 40700
+  return __atomic_fetch_or(pointer, delta, __ATOMIC_ACQUIRE);
+#else
+  return __sync_fetch_and_or(pointer, delta);
+#endif
+}
 /*!
  * Atomic compare and swap operation.
  *

--- a/src/sphdirectpcqueue.h
+++ b/src/sphdirectpcqueue.h
@@ -146,7 +146,7 @@
 typedef void* SPHLFEntryDirect_t;
 
 /** \brief Marks the entry specified by the entry handle as complete.
-*   Also executes write memory barries required by the platform to ensure
+*   Also executes any memory barriers required by the platform to ensure
 *   that all previous stores by this thread to this entry are complete.
 *
 *   @param directHandle Entry Handle for an allocated entry.

--- a/src/sphlflogger.cpp
+++ b/src/sphlflogger.cpp
@@ -269,7 +269,7 @@ SPHLFLoggerAllocTimeStamped (SPHLFLogger_t log,
 						      start_log_buf);
 		    }
 		  while (!done);
-		  __sync_fetch_and_or (&headerBlock->options,
+		  fetch_and_or (&headerBlock->options,
 					      SPHLFLOGGER_CIRCULAR_WRAPED);
 #ifdef __SASDebugPrint__
 		  sas_printf
@@ -400,7 +400,7 @@ SPHLFLoggerAllocStrideTimeStamped (SPHLFLogger_t log,
 						      start_log_buf);
 		    }
 		  while (!done);
-		  __sync_fetch_and_or (&headerBlock->options,
+		  fetch_and_or (&headerBlock->options,
 					      SPHLFLOGGER_CIRCULAR_WRAPED);
 #ifdef __SASDebugPrint__
 		  sas_printf
@@ -1014,9 +1014,8 @@ SPHLFLoggerSetCachePrefetch (SPHLFLogger_t log, int prefetch)
 	  if (prefetch == 1)
 	    prefetch_opt = SPHLFLOGGER_CACHE_PREFETCH0;
 	}
-
-      temp = __sync_fetch_and_and (&headerBlock->options, temp);
-      temp = __sync_fetch_and_or (&headerBlock->options, prefetch_opt);
+      temp = fetch_and_and (&headerBlock->options, temp);
+      temp = fetch_and_or (&headerBlock->options, prefetch_opt);
     }
   else
     {

--- a/src/sphsinglepcqueue.cpp
+++ b/src/sphsinglepcqueue.cpp
@@ -1198,8 +1198,8 @@ SPHSinglePCQueueSetCachePrefetch (SPHSinglePCQueue_t queue, int prefetch)
 	    prefetch_opt = SPHSPCQUEUE_CACHE_PREFETCH0;
 	}
 
-      temp = __sync_fetch_and_and (&headerBlock->options, temp);
-      temp = __sync_fetch_and_or (&headerBlock->options, prefetch_opt);
+      temp = fetch_and_and (&headerBlock->options, temp);
+      temp = fetch_and_or (&headerBlock->options, prefetch_opt);
     }
   else
     {
@@ -1213,7 +1213,7 @@ SPHSinglePCQueueSetCachePrefetch (SPHSinglePCQueue_t queue, int prefetch)
 }
 
 int
-SPHSinglePCQueueSetCachePrefetch (SPHSinglePCQueue_t queue)
+SPHSinglePCQueuePrefetch (SPHSinglePCQueue_t queue)
 {
   SPHPCQueueHeader *headerBlock = (SPHPCQueueHeader *) queue;
   block_size_t logsize, pagesz, i;
@@ -1232,14 +1232,14 @@ SPHSinglePCQueueSetCachePrefetch (SPHSinglePCQueue_t queue)
 	  touchptr += pagesz;
 	  touch += *touchptr;
 #if 0
-	  printf ("SPHSinglePCQueueSetCachePrefetch@%p\n", touchptr);
+	  printf ("SPHSinglePCQueuePrefetch@%p\n", touchptr);
 #endif
 	}
     }
   else
     {
 #ifdef __SASDebugPrint__
-      sas_printf ("SPHSinglePCQueueSetCachePrefetch(%p) type check failed\n",
+      sas_printf ("SPHSinglePCQueuePrefetch(%p) type check failed\n",
     		  queue);
 #endif
       rc = 1;


### PR DESCRIPTION
1.Replaces __sync_fetch_and_and, __sync_fetch_and_or with __atomic_fetch_and
and __atomic_fetch_or builtins.
2.Correct SPHSinglePCQueuePrefetch() function name.

Signed-off-by:  Rajalakshmi Srinivasaraghavan  <raji@linux.vnet.ibm.com>

	* src/bitv.c (bitv_alloc_marked): Use atomic builtins.
	* src/bitv.c (bitv_aligned_alloc_marked): Likewise.
	* src/bitv.c (bitv_dealloc_internal): Likewise.
	* src/bitv.c (GCC_VERSION): Define.
	* src/sasatom.h (fetch_and_and): New function.
	* src/sasatom.h (fetch_and_or): New function.
	* src/sasatom.h (fetch_and_and_long): New function.
	* src/sasatom.h (fetch_and_or_long): New function.
	* src/sphdirectpcqueue.h (SPHLFEntryDirectComplete): Comment typo
	correction.
	* src/sphlflogger.cpp (SPHSinglePCQueueSetCachePrefetch): Use atomic
	builtins.
	* src/sphlflogger.cpp (SPHSinglePCQueuePrefetch): Name correction.
	* src/sphsinglepcqueue.cpp (SPHLFLoggerAllocTimeStamped): Use atomic
	builtins.
	* src/sphsinglepcqueue.cpp (SPHLFLoggerAllocStrideTimeStamped):
	Likewise.
	* src/sphsinglepcqueue.cpp (SPHLFLoggerSetCachePrefetch): Likewise.