### PR TITLE
convert "inline" to "static inline"

### DIFF
--- a/src/sasalloc.h
+++ b/src/sasalloc.h
@@ -118,14 +118,14 @@ extern __C__ void
 initSOMSASBlock(SASBlockHeader *header, sas_type_t sasType,
 					long blockSize, void* blockHeap);
 
-inline int
+static inline int
 SOMSASCheckBlockSig (SASBlockHeader* header)
 {
     return ((header->blockSig1 == block__Signature_1)
 	    &&(header->blockSig2 == block__Signature_2));
 }
 
-inline int
+static inline int
 SOMSASCheckBlockSigAndType (SASBlockHeader* header, 
                                                            sas_type_t sasType)
 {
@@ -135,7 +135,7 @@ SOMSASCheckBlockSigAndType (SASBlockHeader* header,
 	          == (sasType & SAS_TYPE_MASK)));
 }
 
-inline int
+static inline int
 SOMSASCheckBlockSigAndTypeAndSubtype (SASBlockHeader* header, 
                                                            sas_type_t sasType)
 {
@@ -145,7 +145,7 @@ SOMSASCheckBlockSigAndTypeAndSubtype (SASBlockHeader* header,
 	          == (sasType & SAS_SUBTYPE_CHECK_MASK)));
 }
 
-inline int
+static inline int
 SOMSASCheckBlockSubType (SASBlockHeader* header, 
                                                            sas_type_t sasType)
 {
@@ -153,7 +153,7 @@ SOMSASCheckBlockSubType (SASBlockHeader* header,
                  == (sasType & SAS_SUB_TYPE_MASK));
 }
 
-inline void
+static inline void
 SOMSASSetBlockSubType (SASBlockHeader* header, 
                                                            sas_type_t sasType)
 {
@@ -161,13 +161,13 @@ SOMSASSetBlockSubType (SASBlockHeader* header,
                  || (sasType & SAS_SUB_TYPE_MASK);
 }
 
-inline sas_type_t
+static inline sas_type_t
 SOMSASGetBlockSubType (SASBlockHeader* header)
 {
     return (header->blockType &  SAS_SUB_TYPE_MASK);
 }
 
-inline sas_type_t
+static inline sas_type_t
 SOMSASGetBlockType (SASBlockHeader* header)
 {
     return (header->blockType);

--- a/src/sasallocpriv.h
+++ b/src/sasallocpriv.h
@@ -17,13 +17,13 @@
 extern unsigned long memLow __attribute__ ((visibility ("hidden")));
 extern unsigned long memHigh __attribute__ ((visibility ("hidden")));
 
-inline unsigned long
+static inline unsigned long
 getfastMemLow ()
 {
   return memLow;
 }
 
-inline unsigned long
+static inline unsigned long
 getfastMemHigh ()
 {
   return memHigh;

--- a/src/sasmsync.c
+++ b/src/sasmsync.c
@@ -15,7 +15,7 @@
 #include "sasio.h"
 #include "sasmsync.h"
 
-inline void*
+static inline void*
 pageAlignStart (void *startAddr)
 {
 	unsigned long pageSize = getpagesize();
@@ -25,7 +25,7 @@ pageAlignStart (void *startAddr)
 	return (void*)(addr & pageMask);
 }
 
-inline size_t
+static inline size_t
 pageAlignLen (void *startAddr, size_t size)
 {
 	unsigned long pageSize = getpagesize();

--- a/src/sphdirectpcqueue.h
+++ b/src/sphdirectpcqueue.h
@@ -155,7 +155,7 @@ typedef void* SPHLFEntryDirect_t;
 *   @param subcode Subcategory code to the completed entry.
 *   @return a 1 value indicates success.
 */
-inline int
+static inline int
 SPHLFEntryDirectComplete (SPHLFEntryDirect_t directHandle,
                           sphLFEntryID_t entry_template,
                           int catcode, int subcode)
@@ -188,7 +188,7 @@ SPHLFEntryDirectComplete (SPHLFEntryDirect_t directHandle,
 *   @param directHandle Entry Handle for an allocated entry.
 *   @return address the entries free space.
 */
-inline void*
+static inline void*
 SPHLFEntryDirectGetFreePtr (SPHLFEntryDirect_t directHandle)
 {
         char    *ptr    = (char*)directHandle + sizeof (sphLFEntry_t);
@@ -209,7 +209,7 @@ SPHLFEntryDirectGetFreePtr (SPHLFEntryDirect_t directHandle)
 *   @param alignval required alignment of the next value to be added.
 *   @return address the entries free space.
 */
-inline void*
+static inline void*
 SPHLFEntryDirectGetPtrAligned (SPHLFEntryDirect_t directHandle,
 		size_t alignval)
 {
@@ -234,7 +234,7 @@ SPHLFEntryDirectGetPtrAligned (SPHLFEntryDirect_t directHandle,
 *   @param alignval required alignment of the next value to be added.
 *   @return next address within the entry with require alignment.
 */
-inline void*
+static inline void*
 SPHLFEntryDirectIncAndAlign (void *directptr, size_t incval, size_t alignval)
 {
         uintptr_t	ptr		= (uintptr_t)directptr;
@@ -252,7 +252,7 @@ SPHLFEntryDirectIncAndAlign (void *directptr, size_t incval, size_t alignval)
 *   @return true if the entry was complete (SPHLFLoggerEntryComplete
 *           has been called fo this entry). Otherwise False.
 */
-inline int
+static inline int
 SPHLFEntryDirectIsComplete (SPHLFEntryDirect_t directHandle)
 {
     SPHLFEntryHeader_t  *entryPtr = (SPHLFEntryHeader_t*)directHandle;
@@ -266,7 +266,7 @@ SPHLFEntryDirectIsComplete (SPHLFEntryDirect_t directHandle)
 *   @param directHandle Entry Handle for an allocated entry.
 *   @return true if the entry was time stamped. Otherwise False.
 */
-inline int
+static inline int
 SPHLFEntryDirectIsTimestamped (SPHLFEntryDirect_t directHandle)
 {
     SPHLFEntryHeader_t  *entryPtr = (SPHLFEntryHeader_t*)directHandle;
@@ -282,7 +282,7 @@ SPHLFEntryDirectIsTimestamped (SPHLFEntryDirect_t directHandle)
 *   @return the category from the entry, if the entry was valid.
 *   Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFEntryDirectCategory (SPHLFEntryDirect_t directHandle)
 {
     SPHLFEntryHeader_t  *entryPtr = (SPHLFEntryHeader_t*)directHandle;
@@ -304,7 +304,7 @@ SPHLFEntryDirectCategory (SPHLFEntryDirect_t directHandle)
 *       @return the sub-category from the entry, if the entry was valid.
 *       Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFEntryDirectSubcat (SPHLFEntryDirect_t directHandle)
 {
     SPHLFEntryHeader_t  *entryPtr = (SPHLFEntryHeader_t*)directHandle;

--- a/src/sphlfentry.h
+++ b/src/sphlfentry.h
@@ -131,7 +131,7 @@ typedef struct {
 *   @param handlespace Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFEntryStrongComplete (SPHLFEntryHandle_t *handlespace)
 {
     int rc = 0;
@@ -154,7 +154,7 @@ SPHLFEntryStrongComplete (SPHLFEntryHandle_t *handlespace)
 *   @param handlespace Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFEntryWeakComplete (SPHLFEntryHandle_t *handlespace)
 {
     int rc = 0;
@@ -175,7 +175,7 @@ SPHLFEntryWeakComplete (SPHLFEntryHandle_t *handlespace)
 *   @param handlespace Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFEntryComplete (SPHLFEntryHandle_t *handlespace)
 {
     int rc = 0;
@@ -196,7 +196,7 @@ SPHLFEntryComplete (SPHLFEntryHandle_t *handlespace)
 *	@return true if the entry was complete (SPHLFLoggerEntryComplete
 *	has been called fo this entry). Otherwise False.
 */
-inline int
+static inline int
 SPHLFEntryIsComplete (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -209,7 +209,7 @@ SPHLFEntryIsComplete (SPHLFEntryHandle_t *handlespace)
 *   @param handlespace Entry Handle for an allocated entry.
 *	@return true if the entry was time stamped. Otherwise False.
 */
-inline int
+static inline int
 SPHLFEntryIsTimestamped (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -224,7 +224,7 @@ SPHLFEntryIsTimestamped (SPHLFEntryHandle_t *handlespace)
 *	@return the time stamp value from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphtimer_t
+static inline sphtimer_t
 SPHLFEntryTimeStamp (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -243,7 +243,7 @@ SPHLFEntryTimeStamp (SPHLFEntryHandle_t *handlespace)
 *	@return the PID from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphpid16_t
+static inline sphpid16_t
 SPHLFEntryPID (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -262,7 +262,7 @@ SPHLFEntryPID (SPHLFEntryHandle_t *handlespace)
 *	@return the TID from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphpid16_t
+static inline sphpid16_t
 SPHLFEntryTID (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -281,7 +281,7 @@ SPHLFEntryTID (SPHLFEntryHandle_t *handlespace)
 *	@return the address from the entry header, if the entry was valid.
 *	Otherwise return NULL.
 */
-inline SPHLFEntryHeader_t*
+static inline SPHLFEntryHeader_t*
 SPHLFEntryHeader (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -298,7 +298,7 @@ SPHLFEntryHeader (SPHLFEntryHandle_t *handlespace)
 *	@return the category from the entry, if the entry was valid.
 *	Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFEntryCategory (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -319,7 +319,7 @@ SPHLFEntryCategory (SPHLFEntryHandle_t *handlespace)
 *	@return the sub-category from the entry, if the entry was valid.
 *	Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFEntrySubcat (SPHLFEntryHandle_t *handlespace)
 {
     SPHLFEntryHeader_t	*entryPtr = handlespace->entry;
@@ -349,7 +349,7 @@ SPHLFEntrySubcat (SPHLFEntryHandle_t *handlespace)
 *   @param handle Entry Handle for an allocated entry.
 *	@return address the entries free space.
 */
-inline void*
+static inline void*
 SPHLFEntryGetFreePtr (SPHLFEntryHandle_t *handle)
 {
 	char		*ptr	= handle->next;
@@ -380,7 +380,7 @@ SPHLFEntryGetFreePtr (SPHLFEntryHandle_t *handle)
 *	For example if remaining entry space
 *	is insufficient to hold the struct at the required alignment.
 */
-inline  void*
+static inline  void*
 SPHLFEntryGetStructPtr (SPHLFEntryHandle_t *handle,
 		unsigned long __size, unsigned long __align)
 {
@@ -435,7 +435,7 @@ SPHLFEntryGetStructPtr (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold the struct at the required alignment.
 */
-inline  void*
+static inline  void*
 SPHLFEntryAllocStruct (SPHLFEntryHandle_t *handle,
 		unsigned long __size, unsigned long __align)
 {
@@ -473,7 +473,7 @@ SPHLFEntryAllocStruct (SPHLFEntryHandle_t *handle,
 *	For example if the string is too
 *	large for the remain entry free space.
 */
-inline int
+static inline int
 SPHLFEntryAddString (SPHLFEntryHandle_t *handle,
 			char *value)
 {
@@ -503,7 +503,7 @@ SPHLFEntryAddString (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a char.
 */
-inline int
+static inline int
 SPHLFEntryAddChar (SPHLFEntryHandle_t *handle,
 			char value)
 {
@@ -531,7 +531,7 @@ SPHLFEntryAddChar (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a short int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddShort (SPHLFEntryHandle_t *handle,
 			short int value)
 {
@@ -572,7 +572,7 @@ SPHLFEntryAddShort (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddInt (SPHLFEntryHandle_t *handle,
 			int value)
 {
@@ -610,7 +610,7 @@ SPHLFEntryAddInt (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a long int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddLong (SPHLFEntryHandle_t *handle,
 			long value)
 {
@@ -648,7 +648,7 @@ SPHLFEntryAddLong (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a void* plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddPtr (SPHLFEntryHandle_t *handle,
 			void *value)
 {
@@ -686,7 +686,7 @@ SPHLFEntryAddPtr (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a long long int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddLongLong (SPHLFEntryHandle_t *handle,
 			long long value)
 {
@@ -724,7 +724,7 @@ SPHLFEntryAddLongLong (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a float plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddFloat (SPHLFEntryHandle_t *handle,
 			float value)
 {
@@ -762,7 +762,7 @@ SPHLFEntryAddFloat (SPHLFEntryHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a double plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFEntryAddDouble (SPHLFEntryHandle_t *handle,
 			double value)
 {
@@ -800,7 +800,7 @@ SPHLFEntryAddDouble (SPHLFEntryHandle_t *handle,
 *	@return the char value if successful, 0 (NUL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  char
+static inline  char
 SPHLFEntryGetNextChar (SPHLFEntryHandle_t *handle)
 {
 	char	*ptr	= handle->next;
@@ -825,7 +825,7 @@ SPHLFEntryGetNextChar (SPHLFEntryHandle_t *handle)
 *	@return the C string pointer value if successful, 0 (NULL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  char*
+static inline  char*
 SPHLFEntryGetNextString (SPHLFEntryHandle_t *handle)
 {
 	char		*ptr	= handle->next;
@@ -853,7 +853,7 @@ SPHLFEntryGetNextString (SPHLFEntryHandle_t *handle)
 *	@return the short int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline short int
+static inline short int
 SPHLFEntryGetNextShort (SPHLFEntryHandle_t *handle)
 {
 	short int	*ptr	= (short int*)handle->next;
@@ -892,7 +892,7 @@ SPHLFEntryGetNextShort (SPHLFEntryHandle_t *handle)
 *	@return the int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  int
+static inline  int
 SPHLFEntryGetNextInt (SPHLFEntryHandle_t *handle)
 {
 	int		*ptr	= (int*)handle->next;
@@ -928,7 +928,7 @@ SPHLFEntryGetNextInt (SPHLFEntryHandle_t *handle)
 *	@return the long int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  long
+static inline  long
 SPHLFEntryGetNextLong (SPHLFEntryHandle_t *handle)
 {
 	long		*ptr	= (long*)handle->next;
@@ -964,7 +964,7 @@ SPHLFEntryGetNextLong (SPHLFEntryHandle_t *handle)
 *	@return the void* value if successful, 0 (NULL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  void*
+static inline  void*
 SPHLFEntryGetNextPtr (SPHLFEntryHandle_t *handle)
 {
 	void		**ptr	= (void**)handle->next;
@@ -1000,7 +1000,7 @@ SPHLFEntryGetNextPtr (SPHLFEntryHandle_t *handle)
 *	@return the long long int value if successful,0 if the get fails. For example if the next is at the end
 *	of the Logger entry.
 */
-inline  long long
+static inline  long long
 SPHLFEntryGetNextLongLong (SPHLFEntryHandle_t *handle)
 {
 	long long	*ptr	= (long long*)handle->next;
@@ -1036,7 +1036,7 @@ SPHLFEntryGetNextLongLong (SPHLFEntryHandle_t *handle)
 *	@return the float value if successful, 0.0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  float
+static inline  float
 SPHLFEntryGetNextFloat (SPHLFEntryHandle_t *handle)
 {
 	float		*ptr	= (float*)handle->next;
@@ -1072,7 +1072,7 @@ SPHLFEntryGetNextFloat (SPHLFEntryHandle_t *handle)
 *	@return the double value if successful, 0.0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  double
+static inline  double
 SPHLFEntryGetNextDouble (SPHLFEntryHandle_t *handle)
 {
 	double		*ptr	= (double*)handle->next;

--- a/src/sphlflogentry.h
+++ b/src/sphlflogentry.h
@@ -61,7 +61,7 @@
 *   @param handlespace Logger Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFLogEntryStrongComplete (SPHLFLoggerHandle_t *handlespace)
 {
     int rc = 0;
@@ -84,7 +84,7 @@ SPHLFLogEntryStrongComplete (SPHLFLoggerHandle_t *handlespace)
 *   @param handlespace Logger Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFLogEntryWeakComplete (SPHLFLoggerHandle_t *handlespace)
 {
     int rc = 0;
@@ -107,7 +107,7 @@ SPHLFLogEntryWeakComplete (SPHLFLoggerHandle_t *handlespace)
 *   @param handlespace Logger Entry Handle for an allocated entry.
 *	@return a 0 value indicates success.
 */
-inline int
+static inline int
 SPHLFLogEntryComplete (SPHLFLoggerHandle_t *handlespace)
 {
     int rc = 0;
@@ -128,7 +128,7 @@ SPHLFLogEntryComplete (SPHLFLoggerHandle_t *handlespace)
 *	@return true if the entry was complete (SPHLFLoggerEntryComplete
 *	has been called fo this entry). Otherwise False.
 */
-inline int
+static inline int
 SPHLFLogEntryIsComplete (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -141,7 +141,7 @@ SPHLFLogEntryIsComplete (SPHLFLoggerHandle_t *handlespace)
 *   @param handlespace Logger Entry Handle for an allocated entry.
 *	@return true if the entry was time stamped. Otherwise False.
 */
-inline int
+static inline int
 SPHLFLogEntryIsTimestamped (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -156,7 +156,7 @@ SPHLFLogEntryIsTimestamped (SPHLFLoggerHandle_t *handlespace)
 *	@return the time stamp value from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphtimer_t
+static inline sphtimer_t
 SPHLFLogEntryTimeStamp (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -175,7 +175,7 @@ SPHLFLogEntryTimeStamp (SPHLFLoggerHandle_t *handlespace)
 *	@return the PID from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphpid16_t
+static inline sphpid16_t
 SPHLFLogEntryPID (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -194,7 +194,7 @@ SPHLFLogEntryPID (SPHLFLoggerHandle_t *handlespace)
 *	@return the TID from the entry, if the entry was valid
 *	and time stamped. Otherwise return 0.
 */
-inline sphpid16_t
+static inline sphpid16_t
 SPHLFLogEntryTID (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -213,7 +213,7 @@ SPHLFLogEntryTID (SPHLFLoggerHandle_t *handlespace)
 *	@return the address from the entry header, if the entry was valid.
 *	Otherwise return NULL.
 */
-inline SPHLFLogHeader_t*
+static inline SPHLFLogHeader_t*
 SPHLFLogEntryHeader (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -230,7 +230,7 @@ SPHLFLogEntryHeader (SPHLFLoggerHandle_t *handlespace)
 *	@return the category from the entry, if the entry was valid.
 *	Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFLogEntryCategory (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -251,7 +251,7 @@ SPHLFLogEntryCategory (SPHLFLoggerHandle_t *handlespace)
 *	@return the sub-category from the entry, if the entry was valid.
 *	Otherwise return 0.
 */
-inline int
+static inline int
 SPHLFLogEntrySubcat (SPHLFLoggerHandle_t *handlespace)
 {
     SPHLFLogHeader_t	*entryPtr = handlespace->entry;
@@ -281,7 +281,7 @@ SPHLFLogEntrySubcat (SPHLFLoggerHandle_t *handlespace)
 *   @param handle Logger Entry Handle for an allocated entry.
 *	@return address the entries free space.
 */
-inline void*
+static inline void*
 SPHLFLogEntryGetFreePtr (SPHLFLoggerHandle_t *handle)
 {
 	char		*ptr	= handle->next;
@@ -312,7 +312,7 @@ SPHLFLogEntryGetFreePtr (SPHLFLoggerHandle_t *handle)
 *	For example if remaining entry space
 *	is insufficient to hold the struct at the required alignment.
 */
-inline  void*
+static inline  void*
 SPHLFlogEntryGetStructPtr (SPHLFLoggerHandle_t *handle,
 		unsigned long __size, unsigned long __align)
 {
@@ -367,7 +367,7 @@ SPHLFlogEntryGetStructPtr (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold the struct at the required alignment.
 */
-inline  void*
+static inline  void*
 SPHLFlogEntryAllocStruct (SPHLFLoggerHandle_t *handle,
 		unsigned long __size, unsigned long __align)
 {
@@ -405,7 +405,7 @@ SPHLFlogEntryAllocStruct (SPHLFLoggerHandle_t *handle,
 *	For example if the string is too
 *	large for the remain entry free space.
 */
-inline int
+static inline int
 SPHLFlogEntryAddString (SPHLFLoggerHandle_t *handle,
 			char *value)
 {
@@ -435,7 +435,7 @@ SPHLFlogEntryAddString (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a char.
 */
-inline int
+static inline int
 SPHLFlogEntryAddChar (SPHLFLoggerHandle_t *handle,
 			char value)
 {
@@ -463,7 +463,7 @@ SPHLFlogEntryAddChar (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a short int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddShort (SPHLFLoggerHandle_t *handle,
 			short int value)
 {
@@ -504,7 +504,7 @@ SPHLFlogEntryAddShort (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddInt (SPHLFLoggerHandle_t *handle,
 			int value)
 {
@@ -542,7 +542,7 @@ SPHLFlogEntryAddInt (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a long int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddLong (SPHLFLoggerHandle_t *handle,
 			long value)
 {
@@ -580,7 +580,7 @@ SPHLFlogEntryAddLong (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a void* plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddPtr (SPHLFLoggerHandle_t *handle,
 			void *value)
 {
@@ -618,7 +618,7 @@ SPHLFlogEntryAddPtr (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a long long int plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddLongLong (SPHLFLoggerHandle_t *handle,
 			long long value)
 {
@@ -656,7 +656,7 @@ SPHLFlogEntryAddLongLong (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a float plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddFloat (SPHLFLoggerHandle_t *handle,
 			float value)
 {
@@ -694,7 +694,7 @@ SPHLFlogEntryAddFloat (SPHLFLoggerHandle_t *handle,
 *	For example if remaining entry space
 *	is insufficient to hold a double plus any required alignment.
 */
-inline  int
+static inline  int
 SPHLFlogEntryAddDouble (SPHLFLoggerHandle_t *handle,
 			double value)
 {
@@ -732,7 +732,7 @@ SPHLFlogEntryAddDouble (SPHLFLoggerHandle_t *handle,
 *	@return the char value if successful, 0 (NUL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  char
+static inline  char
 SPHLFlogEntryGetNextChar (SPHLFLoggerHandle_t *handle)
 {
 	char	*ptr	= handle->next;
@@ -757,7 +757,7 @@ SPHLFlogEntryGetNextChar (SPHLFLoggerHandle_t *handle)
 *	@return the C string pointer value if successful, 0 (NULL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  char*
+static inline  char*
 SPHLFlogEntryGetNextString (SPHLFLoggerHandle_t *handle)
 {
 	char		*ptr	= handle->next;
@@ -785,7 +785,7 @@ SPHLFlogEntryGetNextString (SPHLFLoggerHandle_t *handle)
 *	@return the short int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline short int
+static inline short int
 SPHLFlogEntryGetNextShort (SPHLFLoggerHandle_t *handle)
 {
 	short int	*ptr	= (short int*)handle->next;
@@ -824,7 +824,7 @@ SPHLFlogEntryGetNextShort (SPHLFLoggerHandle_t *handle)
 *	@return the int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  int
+static inline  int
 SPHLFlogEntryGetNextInt (SPHLFLoggerHandle_t *handle)
 {
 	int		*ptr	= (int*)handle->next;
@@ -860,7 +860,7 @@ SPHLFlogEntryGetNextInt (SPHLFLoggerHandle_t *handle)
 *	@return the long int value if successful, 0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  long
+static inline  long
 SPHLFlogEntryGetNextLong (SPHLFLoggerHandle_t *handle)
 {
 	long		*ptr	= (long*)handle->next;
@@ -896,7 +896,7 @@ SPHLFlogEntryGetNextLong (SPHLFLoggerHandle_t *handle)
 *	@return the void* value if successful, 0 (NULL) if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  void*
+static inline  void*
 SPHLFlogEntryGetNextPtr (SPHLFLoggerHandle_t *handle)
 {
 	void		**ptr	= (void**)handle->next;
@@ -932,7 +932,7 @@ SPHLFlogEntryGetNextPtr (SPHLFLoggerHandle_t *handle)
 *	@return the long long int value if successful,0 if the get fails. For example if the next is at the end
 *	of the Logger entry.
 */
-inline  long long
+static inline  long long
 SPHLFlogEntryGetNextLongLong (SPHLFLoggerHandle_t *handle)
 {
 	long long	*ptr	= (long long*)handle->next;
@@ -968,7 +968,7 @@ SPHLFlogEntryGetNextLongLong (SPHLFLoggerHandle_t *handle)
 *	@return the float value if successful, 0.0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  float
+static inline  float
 SPHLFlogEntryGetNextFloat (SPHLFLoggerHandle_t *handle)
 {
 	float		*ptr	= (float*)handle->next;
@@ -1004,7 +1004,7 @@ SPHLFlogEntryGetNextFloat (SPHLFLoggerHandle_t *handle)
 *	@return the double value if successful, 0.0 if the get fails.
 *	For example if the next is at the end of the Logger entry.
 */
-inline  double
+static inline  double
 SPHLFlogEntryGetNextDouble (SPHLFLoggerHandle_t *handle)
 {
 	double		*ptr	= (double*)handle->next;


### PR DESCRIPTION
newer compilers will not automatically incorporate visible "inline" functions, potentially leading to link-time errors.

"static inline" is needed to inline visible function bodies.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>