### PR TITLE
[MPMCQ] remove use of GNU Transactional Memory

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -27,9 +27,6 @@
 /* Define to 1 if you have the `c' library (-lc). */
 #undef HAVE_LIBC
 
-/* Define to 1 if you have the `itm' library (-litm). */
-#undef HAVE_LIBITM
-
 /* Define to 1 if your system has a GNU libc compatible `malloc' function, and
    to 0 otherwise. */
 #undef HAVE_MALLOC

--- a/configure
+++ b/configure
@@ -659,6 +659,8 @@ DX_ENV
 DX_DOCDIR
 DX_CONFIG
 DX_PROJECT
+HTM_FALSE
+HTM_TRUE
 PTHREAD_CFLAGS
 PTHREAD_LIBS
 PTHREAD_CC
@@ -16996,9 +16998,18 @@ if test "x$ax_cv_check_cflags___mhtm" = xyes; then :
 
         CFLAGS="$CFLAGS -mhtm"
         CXXFLAGS="$CXXFLAGS -mhtm"
+        htm=true
 
 else
   :
+fi
+
+ if test x$htm = xtrue; then
+  HTM_TRUE=
+  HTM_FALSE='#'
+else
+  HTM_TRUE='#'
+  HTM_FALSE=
 fi
 
 
@@ -17977,6 +17988,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${am__fastdepCC_TRUE}" && test -z "${am__fastdepCC_FALSE}"; then
   as_fn_error $? "conditional \"am__fastdepCC\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HTM_TRUE}" && test -z "${HTM_FALSE}"; then
+  as_fn_error $? "conditional \"HTM\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${DX_COND_doc_TRUE}" && test -z "${DX_COND_doc_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -114,16 +114,12 @@ AC_CHECK_LIB([c], [printf], [],
 LDFLAGS="$SAVE_LDFLAGS"
 fi
 
-AX_CHECK_COMPILE_FLAG([-fgnu-tm],[
-        CFLAGS="$CFLAGS -fgnu-tm -DHAS_GNU_TM"
-        CXXFLAGS="$CXXFLAGS -fgnu-tm -DHAS_GNU_TM"
-        AC_CHECK_LIB([itm], [_ITM_libraryVersion], [],
-                AC_MSG_ERROR([*** libitm not found. Try to install libitm.]))
-])
 AX_CHECK_COMPILE_FLAG([-mhtm],[
         CFLAGS="$CFLAGS -mhtm"
         CXXFLAGS="$CXXFLAGS -mhtm"
+        htm=true
 ])
+AM_CONDITIONAL([HTM], [test x$htm = xtrue])
 
 # Doxygen support
 DX_HTML_FEATURE(ON)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,6 @@ libsphdeinclude_HEADERS = \
 	sasstringbtree.h \
 	sasstringbtreeenum.h \
 	sasstringbtreenode.h \
-	sphmultipcqueue.h \
 	sphsinglepcqueue.h \
 	sphdirectpcqueue.h \
 	sphlfentry.h \
@@ -126,6 +125,7 @@ libsphde_la_SOURCES = \
 	sphcontextpriv.h
 
 if HTM
+libsphdeinclude_HEADERS += sphmultipcqueue.h
 libsphde_la_SOURCES += sphmultipcqueue.cpp
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,10 +121,13 @@ libsphde_la_SOURCES = \
 	sphlockfreeheap.cpp \
 	sphlflogger.cpp \
 	sphlogportal.cpp \
-	sphmultipcqueue.cpp \
 	sphsinglepcqueue.cpp \
 	sasallocpriv.h \
 	sphcontextpriv.h
+
+if HTM
+libsphde_la_SOURCES += sphmultipcqueue.cpp
+endif
 
 libsphde_la_CFLAGS   = -D__SASSIM__ $(AM_CFLAGS)
 libsphde_la_CXXFLAGS = -D__SASSIM__ $(AM_CXXFLAGS)
@@ -251,8 +254,10 @@ TESTS                 += sphdirectpcqueue_ttt
 sphdirectpcqueue_ttt_SOURCES = tests/sphdirectpcqueue_ttt.c
 sphdirectpcqueue_ttt_LDADD   = libsphde.la
 
+if HTM
 TESTS                 += sphmultipcqueue_t
 sphmultipcqueue_t_SOURCES = tests/sphmultipcqueue_t.c
 sphmultipcqueue_t_LDADD   = libsphde.la
+endif
 
 check_PROGRAMS = $(TESTS)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -81,6 +81,7 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 bin_PROGRAMS = sasutil$(EXEEXT)
+@HTM_TRUE@am__append_1 = sphmultipcqueue.cpp
 TESTS = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) sasatom_t$(EXEEXT) \
 	bitvec_t$(EXEEXT) sassim_t$(EXEEXT) sascompoundheap_t$(EXEEXT) \
 	sasseg_t$(EXEEXT) sphlockfreeheap_t$(EXEEXT) \
@@ -91,8 +92,9 @@ TESTS = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) sasatom_t$(EXEEXT) \
 	sasstringbtree_t$(EXEEXT) sasstringbtree_tt$(EXEEXT) \
 	sphsinglepcqueue_t$(EXEEXT) sphsinglepcqueue_tt$(EXEEXT) \
 	sphsinglepcqueue_ttt$(EXEEXT) sphdirectpcqueue_ttt$(EXEEXT) \
-	sphmultipcqueue_t$(EXEEXT)
-check_PROGRAMS = $(am__EXEEXT_1)
+	$(am__EXEEXT_1)
+@HTM_TRUE@am__append_2 = sphmultipcqueue_t
+check_PROGRAMS = $(am__EXEEXT_2)
 subdir = src
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/depcomp $(libsphdeinclude_HEADERS) \
@@ -145,6 +147,16 @@ am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" \
 LTLIBRARIES = $(lib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
 libsphde_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
+am__libsphde_la_SOURCES_DIST = sasshm.c sasmsync.c sasstname.c sasio.c \
+	bitv.c freenode.c sphtimer.c sphthread.c sassim.cpp \
+	sasalloc.cpp ultree.cpp saslock.cpp sasmlock.cpp sasulock.cpp \
+	sassimplespace.cpp sassimplestack.cpp sassimpleheap.cpp \
+	sascompoundheap.cpp sasindex.cpp sasindexnode.cpp \
+	sasindexenum.cpp sasstringbtreenode.cpp sasstringbtree.cpp \
+	sasstringbtreeenum.cpp sphcontext.cpp sphlockfreeheap.cpp \
+	sphlflogger.cpp sphlogportal.cpp sphsinglepcqueue.cpp \
+	sasallocpriv.h sphcontextpriv.h sphmultipcqueue.cpp
+@HTM_TRUE@am__objects_1 = libsphde_la-sphmultipcqueue.lo
 am_libsphde_la_OBJECTS = libsphde_la-sasshm.lo libsphde_la-sasmsync.lo \
 	libsphde_la-sasstname.lo libsphde_la-sasio.lo \
 	libsphde_la-bitv.lo libsphde_la-freenode.lo \
@@ -159,8 +171,8 @@ am_libsphde_la_OBJECTS = libsphde_la-sasshm.lo libsphde_la-sasmsync.lo \
 	libsphde_la-sasstringbtree.lo \
 	libsphde_la-sasstringbtreeenum.lo libsphde_la-sphcontext.lo \
 	libsphde_la-sphlockfreeheap.lo libsphde_la-sphlflogger.lo \
-	libsphde_la-sphlogportal.lo libsphde_la-sphmultipcqueue.lo \
-	libsphde_la-sphsinglepcqueue.lo
+	libsphde_la-sphlogportal.lo libsphde_la-sphsinglepcqueue.lo \
+	$(am__objects_1)
 libsphde_la_OBJECTS = $(am_libsphde_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -182,7 +194,8 @@ libsphgtod_la_OBJECTS = $(am_libsphgtod_la_OBJECTS)
 libsphgtod_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libsphgtod_la_CFLAGS) \
 	$(CFLAGS) $(libsphgtod_la_LDFLAGS) $(LDFLAGS) -o $@
-am__EXEEXT_1 = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) \
+@HTM_TRUE@am__EXEEXT_1 = sphmultipcqueue_t$(EXEEXT)
+am__EXEEXT_2 = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) \
 	sasatom_t$(EXEEXT) bitvec_t$(EXEEXT) sassim_t$(EXEEXT) \
 	sascompoundheap_t$(EXEEXT) sasseg_t$(EXEEXT) \
 	sphlockfreeheap_t$(EXEEXT) sphlflogger_t$(EXEEXT) \
@@ -193,7 +206,7 @@ am__EXEEXT_1 = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) \
 	sasstringbtree_t$(EXEEXT) sasstringbtree_tt$(EXEEXT) \
 	sphsinglepcqueue_t$(EXEEXT) sphsinglepcqueue_tt$(EXEEXT) \
 	sphsinglepcqueue_ttt$(EXEEXT) sphdirectpcqueue_ttt$(EXEEXT) \
-	sphmultipcqueue_t$(EXEEXT)
+	$(am__EXEEXT_1)
 PROGRAMS = $(bin_PROGRAMS)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_bitvec_t_OBJECTS = tests/bitvec_t.$(OBJEXT)
@@ -267,9 +280,11 @@ sphlogportal_t_DEPENDENCIES = libsphde.la
 am_sphlogportal_tt_OBJECTS = tests/sphlogportal_t.$(OBJEXT)
 sphlogportal_tt_OBJECTS = $(am_sphlogportal_tt_OBJECTS)
 sphlogportal_tt_DEPENDENCIES = libsphde.la
-am_sphmultipcqueue_t_OBJECTS = tests/sphmultipcqueue_t.$(OBJEXT)
+am__sphmultipcqueue_t_SOURCES_DIST = tests/sphmultipcqueue_t.c
+@HTM_TRUE@am_sphmultipcqueue_t_OBJECTS =  \
+@HTM_TRUE@	tests/sphmultipcqueue_t.$(OBJEXT)
 sphmultipcqueue_t_OBJECTS = $(am_sphmultipcqueue_t_OBJECTS)
-sphmultipcqueue_t_DEPENDENCIES = libsphde.la
+@HTM_TRUE@sphmultipcqueue_t_DEPENDENCIES = libsphde.la
 am_sphsinglepcqueue_t_OBJECTS = tests/sphsinglepcqueue_t.$(OBJEXT)
 sphsinglepcqueue_t_OBJECTS = $(am_sphsinglepcqueue_t_OBJECTS)
 sphsinglepcqueue_t_DEPENDENCIES = libsphde.la
@@ -349,18 +364,19 @@ SOURCES = $(libsphde_la_SOURCES) $(libsphgettime_la_SOURCES) \
 	$(sphlogportal_tt_SOURCES) $(sphmultipcqueue_t_SOURCES) \
 	$(sphsinglepcqueue_t_SOURCES) $(sphsinglepcqueue_tt_SOURCES) \
 	$(sphsinglepcqueue_ttt_SOURCES) $(sphthread_t_SOURCES)
-DIST_SOURCES = $(libsphde_la_SOURCES) $(libsphgettime_la_SOURCES) \
-	$(libsphgtod_la_SOURCES) $(bitvec_t_SOURCES) \
-	$(sasatom_t_SOURCES) $(sascompoundheap_t_SOURCES) \
-	$(sasindex_t_SOURCES) $(sasindex_tt_SOURCES) \
-	$(sasseg_t_SOURCES) $(sassim_t_SOURCES) \
+DIST_SOURCES = $(am__libsphde_la_SOURCES_DIST) \
+	$(libsphgettime_la_SOURCES) $(libsphgtod_la_SOURCES) \
+	$(bitvec_t_SOURCES) $(sasatom_t_SOURCES) \
+	$(sascompoundheap_t_SOURCES) $(sasindex_t_SOURCES) \
+	$(sasindex_tt_SOURCES) $(sasseg_t_SOURCES) $(sassim_t_SOURCES) \
 	$(sasstringbtree_t_SOURCES) $(sasstringbtree_tt_SOURCES) \
 	$(sasutil_SOURCES) $(sphcontext_t_SOURCES) \
 	$(sphdirectpcqueue_ttt_SOURCES) $(sphgettime_t_SOURCES) \
 	$(sphgtod_t_SOURCES) $(sphlflogger_t_SOURCES) \
 	$(sphlflogger_tt_SOURCES) $(sphlflogger_ttt_SOURCES) \
 	$(sphlockfreeheap_t_SOURCES) $(sphlogportal_t_SOURCES) \
-	$(sphlogportal_tt_SOURCES) $(sphmultipcqueue_t_SOURCES) \
+	$(sphlogportal_tt_SOURCES) \
+	$(am__sphmultipcqueue_t_SOURCES_DIST) \
 	$(sphsinglepcqueue_t_SOURCES) $(sphsinglepcqueue_tt_SOURCES) \
 	$(sphsinglepcqueue_ttt_SOURCES) $(sphthread_t_SOURCES)
 am__can_run_installinfo = \
@@ -786,40 +802,15 @@ libsphde_la_INCLUDES = \
 
 libsphgtod_la_SOURCES = sphgtod.c
 libsphgettime_la_SOURCES = sphgettime.c
-libsphde_la_SOURCES = \
-	sasshm.c \
-	sasmsync.c \
-	sasstname.c \
-	sasio.c \
-	bitv.c \
-	freenode.c \
-	sphtimer.c \
-	sphthread.c \
-	sassim.cpp \
-	sasalloc.cpp \
-	ultree.cpp \
-	saslock.cpp \
-	sasmlock.cpp \
-	sasulock.cpp \
-	sassimplespace.cpp \
-	sassimplestack.cpp \
-	sassimpleheap.cpp \
-	sascompoundheap.cpp \
-	sasindex.cpp \
-	sasindexnode.cpp \
-	sasindexenum.cpp \
-	sasstringbtreenode.cpp \
-	sasstringbtree.cpp \
-	sasstringbtreeenum.cpp \
-	sphcontext.cpp \
-	sphlockfreeheap.cpp \
-	sphlflogger.cpp \
-	sphlogportal.cpp \
-	sphmultipcqueue.cpp \
-	sphsinglepcqueue.cpp \
-	sasallocpriv.h \
-	sphcontextpriv.h
-
+libsphde_la_SOURCES = sasshm.c sasmsync.c sasstname.c sasio.c bitv.c \
+	freenode.c sphtimer.c sphthread.c sassim.cpp sasalloc.cpp \
+	ultree.cpp saslock.cpp sasmlock.cpp sasulock.cpp \
+	sassimplespace.cpp sassimplestack.cpp sassimpleheap.cpp \
+	sascompoundheap.cpp sasindex.cpp sasindexnode.cpp \
+	sasindexenum.cpp sasstringbtreenode.cpp sasstringbtree.cpp \
+	sasstringbtreeenum.cpp sphcontext.cpp sphlockfreeheap.cpp \
+	sphlflogger.cpp sphlogportal.cpp sphsinglepcqueue.cpp \
+	sasallocpriv.h sphcontextpriv.h $(am__append_1)
 libsphde_la_CFLAGS = -D__SASSIM__ $(AM_CFLAGS)
 libsphde_la_CXXFLAGS = -D__SASSIM__ $(AM_CXXFLAGS)
 libsphgtod_la_CFLAGS = $(AM_CFLAGS)
@@ -888,8 +879,8 @@ sphsinglepcqueue_ttt_SOURCES = tests/sphsinglepcqueue_ttt.c
 sphsinglepcqueue_ttt_LDADD = libsphde.la
 sphdirectpcqueue_ttt_SOURCES = tests/sphdirectpcqueue_ttt.c
 sphdirectpcqueue_ttt_LDADD = libsphde.la
-sphmultipcqueue_t_SOURCES = tests/sphmultipcqueue_t.c
-sphmultipcqueue_t_LDADD = libsphde.la
+@HTM_TRUE@sphmultipcqueue_t_SOURCES = tests/sphmultipcqueue_t.c
+@HTM_TRUE@sphmultipcqueue_t_LDADD = libsphde.la
 all: all-am
 
 .SUFFIXES:
@@ -1529,19 +1520,19 @@ libsphde_la-sphlogportal.lo: sphlogportal.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -c -o libsphde_la-sphlogportal.lo `test -f 'sphlogportal.cpp' || echo '$(srcdir)/'`sphlogportal.cpp
 
-libsphde_la-sphmultipcqueue.lo: sphmultipcqueue.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -MT libsphde_la-sphmultipcqueue.lo -MD -MP -MF $(DEPDIR)/libsphde_la-sphmultipcqueue.Tpo -c -o libsphde_la-sphmultipcqueue.lo `test -f 'sphmultipcqueue.cpp' || echo '$(srcdir)/'`sphmultipcqueue.cpp
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libsphde_la-sphmultipcqueue.Tpo $(DEPDIR)/libsphde_la-sphmultipcqueue.Plo
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sphmultipcqueue.cpp' object='libsphde_la-sphmultipcqueue.lo' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -c -o libsphde_la-sphmultipcqueue.lo `test -f 'sphmultipcqueue.cpp' || echo '$(srcdir)/'`sphmultipcqueue.cpp
-
 libsphde_la-sphsinglepcqueue.lo: sphsinglepcqueue.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -MT libsphde_la-sphsinglepcqueue.lo -MD -MP -MF $(DEPDIR)/libsphde_la-sphsinglepcqueue.Tpo -c -o libsphde_la-sphsinglepcqueue.lo `test -f 'sphsinglepcqueue.cpp' || echo '$(srcdir)/'`sphsinglepcqueue.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libsphde_la-sphsinglepcqueue.Tpo $(DEPDIR)/libsphde_la-sphsinglepcqueue.Plo
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sphsinglepcqueue.cpp' object='libsphde_la-sphsinglepcqueue.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -c -o libsphde_la-sphsinglepcqueue.lo `test -f 'sphsinglepcqueue.cpp' || echo '$(srcdir)/'`sphsinglepcqueue.cpp
+
+libsphde_la-sphmultipcqueue.lo: sphmultipcqueue.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -MT libsphde_la-sphmultipcqueue.lo -MD -MP -MF $(DEPDIR)/libsphde_la-sphmultipcqueue.Tpo -c -o libsphde_la-sphmultipcqueue.lo `test -f 'sphmultipcqueue.cpp' || echo '$(srcdir)/'`sphmultipcqueue.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libsphde_la-sphmultipcqueue.Tpo $(DEPDIR)/libsphde_la-sphmultipcqueue.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sphmultipcqueue.cpp' object='libsphde_la-sphmultipcqueue.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libsphde_la_CXXFLAGS) $(CXXFLAGS) -c -o libsphde_la-sphmultipcqueue.lo `test -f 'sphmultipcqueue.cpp' || echo '$(srcdir)/'`sphmultipcqueue.cpp
 
 mostlyclean-libtool:
 	-rm -f *.lo

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -81,7 +81,8 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 bin_PROGRAMS = sasutil$(EXEEXT)
-@HTM_TRUE@am__append_1 = sphmultipcqueue.cpp
+@HTM_TRUE@am__append_1 = sphmultipcqueue.h
+@HTM_TRUE@am__append_2 = sphmultipcqueue.cpp
 TESTS = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) sasatom_t$(EXEEXT) \
 	bitvec_t$(EXEEXT) sassim_t$(EXEEXT) sascompoundheap_t$(EXEEXT) \
 	sasseg_t$(EXEEXT) sphlockfreeheap_t$(EXEEXT) \
@@ -93,11 +94,11 @@ TESTS = sphgtod_t$(EXEEXT) sphgettime_t$(EXEEXT) sasatom_t$(EXEEXT) \
 	sphsinglepcqueue_t$(EXEEXT) sphsinglepcqueue_tt$(EXEEXT) \
 	sphsinglepcqueue_ttt$(EXEEXT) sphdirectpcqueue_ttt$(EXEEXT) \
 	$(am__EXEEXT_1)
-@HTM_TRUE@am__append_2 = sphmultipcqueue_t
+@HTM_TRUE@am__append_3 = sphmultipcqueue_t
 check_PROGRAMS = $(am__EXEEXT_2)
 subdir = src
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
-	$(top_srcdir)/depcomp $(libsphdeinclude_HEADERS) \
+	$(top_srcdir)/depcomp $(am__libsphdeinclude_HEADERS_DIST) \
 	$(libsphgettimeinclude_HEADERS) $(libsphgtodinclude_HEADERS) \
 	$(top_srcdir)/test-driver
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -384,6 +385,16 @@ am__can_run_installinfo = \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
+am__libsphdeinclude_HEADERS_DIST = sasatom.h sasatom_generic.h \
+	sasatom_i386.h sasatom_powerpc.h sasatom_x86_64.h \
+	sascompoundheap.h sphcompoundpcqheap.h sasindexenum.h sassim.h \
+	sasalloc.h sphcontext.h saslock.h sasmsync.h sasindex.h \
+	sasindexnode.h sasindexkey.h freenode.h sasconf.h sastype.h \
+	sasstname.h sassimpleheap.h sassimplespace.h sassimplestack.h \
+	sasstringbtree.h sasstringbtreeenum.h sasstringbtreenode.h \
+	sphsinglepcqueue.h sphdirectpcqueue.h sphlfentry.h \
+	sphlflogentry.h sphlflogger.h sphlockfreeheap.h sphlogportal.h \
+	sphthread.h sphtimer.h sphmultipcqueue.h
 HEADERS = $(libsphdeinclude_HEADERS) $(libsphgettimeinclude_HEADERS) \
 	$(libsphgtodinclude_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
@@ -739,44 +750,16 @@ libsphgettimeincludedir = $(includedir)/sphde
 
 # The headers in 'libsphdeinclude_HEADERS' are meant to be the ones installed
 # on 'make install'
-libsphdeinclude_HEADERS = \
-	sasatom.h \
-	sasatom_generic.h \
-	sasatom_i386.h \
-	sasatom_powerpc.h \
-	sasatom_x86_64.h \
-	sascompoundheap.h \
-	sphcompoundpcqheap.h \
-	sasindexenum.h \
-	sassim.h \
-	sasalloc.h \
-	sphcontext.h \
-	saslock.h \
-	sasmsync.h \
-	sasindex.h \
-	sasindexnode.h \
-	sasindexkey.h \
-	freenode.h \
-	sasconf.h \
-	sastype.h \
-	sasstname.h \
-	sassimpleheap.h \
-	sassimplespace.h \
-	sassimplestack.h \
-	sasstringbtree.h \
-	sasstringbtreeenum.h \
-	sasstringbtreenode.h \
-	sphmultipcqueue.h \
-	sphsinglepcqueue.h \
-	sphdirectpcqueue.h \
-	sphlfentry.h \
-	sphlflogentry.h \
-	sphlflogger.h \
-	sphlockfreeheap.h \
-	sphlogportal.h \
-	sphthread.h \
-	sphtimer.h
-
+libsphdeinclude_HEADERS = sasatom.h sasatom_generic.h sasatom_i386.h \
+	sasatom_powerpc.h sasatom_x86_64.h sascompoundheap.h \
+	sphcompoundpcqheap.h sasindexenum.h sassim.h sasalloc.h \
+	sphcontext.h saslock.h sasmsync.h sasindex.h sasindexnode.h \
+	sasindexkey.h freenode.h sasconf.h sastype.h sasstname.h \
+	sassimpleheap.h sassimplespace.h sassimplestack.h \
+	sasstringbtree.h sasstringbtreeenum.h sasstringbtreenode.h \
+	sphsinglepcqueue.h sphdirectpcqueue.h sphlfentry.h \
+	sphlflogentry.h sphlflogger.h sphlockfreeheap.h sphlogportal.h \
+	sphthread.h sphtimer.h $(am__append_1)
 libsphgtodinclude_HEADERS = sphgtod.h
 libsphgettimeinclude_HEADERS = sphgettime.h
 libsphde_la_INCLUDES = \
@@ -810,7 +793,7 @@ libsphde_la_SOURCES = sasshm.c sasmsync.c sasstname.c sasio.c bitv.c \
 	sasindexenum.cpp sasstringbtreenode.cpp sasstringbtree.cpp \
 	sasstringbtreeenum.cpp sphcontext.cpp sphlockfreeheap.cpp \
 	sphlflogger.cpp sphlogportal.cpp sphsinglepcqueue.cpp \
-	sasallocpriv.h sphcontextpriv.h $(am__append_1)
+	sasallocpriv.h sphcontextpriv.h $(am__append_2)
 libsphde_la_CFLAGS = -D__SASSIM__ $(AM_CFLAGS)
 libsphde_la_CXXFLAGS = -D__SASSIM__ $(AM_CXXFLAGS)
 libsphgtod_la_CFLAGS = $(AM_CFLAGS)

--- a/src/sphmultipcqueue.h
+++ b/src/sphmultipcqueue.h
@@ -36,7 +36,7 @@ typedef struct data_struct11 {
 } data_struct11;
 
 // Allocate zero copy queue entry
-handle = SPHMPMCQMultiAllocStrideDirectTM (pcqueue);
+handle = SPHMPMCQMultiAllocStrideDirectHTM (pcqueue);
 if (handle)
 {	// insert data into the allocated queue entry
 	sphLFEntryID_t tmpl;
@@ -84,7 +84,7 @@ typedef struct data_struct11 {
 } data_struct11;
 
 // Get next queue entry
-handle = SPHMPMCQGetNextCompleteDirectTM (pcqueue);
+handle = SPHMPMCQGetNextCompleteDirectHTM (pcqueue);
 if (handle)
 {	// insert data into the allocated queue entry
 	data_struct11 *struct_ptr;
@@ -327,7 +327,7 @@ SPHMPMCQGetEntryTemplate (SPHMPMCQ_t queue);
 *       For example the Allocate may fail if the queue is full.
 */
 extern __C__ SPHLFEntryDirect_t
-SPHMPMCQAllocStrideDirectTM (SPHMPMCQ_t queue);
+SPHMPMCQAllocStrideDirectHTM (SPHMPMCQ_t queue);
 
 /** \brief Allows the producer thread to allocate and initialize the
 *   header of a queue entry for access. The allocation is from the
@@ -373,7 +373,7 @@ SPHSPMCQAllocStrideDirect(SPHMPMCQ_t queue);
 *       is empty or the next tail entry is not yet completed.
 */
 extern __C__ SPHLFEntryDirect_t
-SPHMPMCQGetNextCompleteDirectTM (SPHMPMCQ_t queue);
+SPHMPMCQGetNextCompleteDirectHTM (SPHMPMCQ_t queue);
 
 /** \brief Allows the consumer to get the next completed queue entry
 *       from the specified multi producer multi consumer queue.


### PR DESCRIPTION
Use of GNU Transactional Memory, because of its need to support
Software Transactional Memory (STM), requires wrapping every access
writes as well as reads, to possibly contended memory inside
"__transaction_atomic".

The lock-free structures within SPHDE use tiny inline functions
to mark queue entries "complete".  It is not desirable nor performant
to wrap these functions (which are realized as a single store
instruction) within transactions, nor is it (currently) desirable
to create a new "GNU-TM" version of those functions, as that would
force the user of the API to know whether they are using GNU-TM or
not.  An API which can transparently use HTM for performance and
GNU-TM as a fallback is preferred, but not easily implemented
given the above requirements.

For now, remove use of GNU-TM completely, leaving the MPMC queue
implementation with HTM support only, which implies support of
the MPMC queue API only on platforms that support HTM.

The MPMC test case will not be built when the compiler does not
support HTM, and will run, but only to report success, on systems
that do not support HTM.

Note that the API has changed for affected functions.  Function names changed s/TM/HTM/:
- SPHMPMCQAllocStrideDirectHTM
- SPHMPMCQGetNextCompleteDirectHTM

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>