### PR TITLE
Fix FTBFS on s390x

### DIFF
--- a/src/tests/sphmultipcqueue_t.c
+++ b/src/tests/sphmultipcqueue_t.c
@@ -918,7 +918,11 @@ void compute_stats(unsigned long count, sphtimer_t delta, double *per, double *r
 int
 main(int argc, char *argv[]) {
 	unsigned long hwcap2 = getauxval(AT_HWCAP2);
+#ifdef __s390x__
+	if ((hwcap2 & HWCAP_S390_TE) == 0) {
+#else
 	if ((hwcap2 & PPC_FEATURE2_HAS_HTM) == 0) {
+#endif
 		fprintf(stderr,"MPMCQ requires Hardware Transactional Memory support.\n");
 		exit(0);
 	}


### PR DESCRIPTION
Hi,
In last upstream version, TM related code has changed and now fails on
s390x. This is an attempt to fix things basically.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=906798
- first, try to detect Transactional Execution support on s390x
- as __TM_begin has a different argument specifically on s390x, and the current
code does not make use of the return transaction diagnostic block, let's use the __TM_simple_begin call that has the same prototype on all archs.

This compiles and test looks ok.

Signed-off-by: Frédéric Bonnard <frediz@debian.org>