### PR TITLE
Improve integration of new platforms. Close #72

### DIFF
--- a/src/sasanchr.h
+++ b/src/sasanchr.h
@@ -24,12 +24,7 @@
 typedef struct
 {
 #ifdef __WORDSIZE_64
-#if defined (__x86_64__) || \
-    (defined (__LITTLE_ENDIAN__) && defined (__powerpc64__)) \
-    || defined (__aarch64__) || defined (__arm__) \
-    || ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && defined(__mips64)) \
-    || defined (__loongarch__) \
-    || defined (__riscv)
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   unsigned int compactUseList:1;
   unsigned long reserved0:63;
 #else

--- a/src/sasconf.h
+++ b/src/sasconf.h
@@ -132,7 +132,7 @@
 #endif
 
 /* 
- * If the platform is not recognized above, select some resonable default.
+ * If the platform is not recognized above, select some reasonable default.
  */
 #ifndef __SAS_BASE_ADDRESS
 # ifdef __GNUC__
@@ -149,14 +149,18 @@
 
 #define __SAS_TEMP_FREE    (__SAS_BASE_ADDRESS + RegionSize + 4*SegmentSize)
 
-
 #ifndef __SAS_SHMAP_MAX
 # define __SAS_SHMAP_MAX SegmentSize
 #endif
 
+// In case platform config does not define __WORDSIZE
 #ifndef __WORDSIZE_64
 # ifndef __WORDSIZE_32
-#  define __WORDSIZE_32
+#  ifdef __LP64__
+#    define __WORDSIZE_64
+#  else
+#    define __WORDSIZE_32
+#  endif
 # endif
 #endif
 

--- a/src/sassim.cpp
+++ b/src/sassim.cpp
@@ -124,12 +124,7 @@ unsigned long logTable[maxLog2] = { 0x1000,	// 00 = 004k
 typedef struct
 {
 #ifdef __WORDSIZE_64
-#if defined (__x86_64__) || \
-    (defined (__LITTLE_ENDIAN__) && defined (__powerpc64__)) \
-    || defined (__aarch64__) || defined (__arm__) \
-    || ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && defined(__mips64)) \
-    || defined (__loongarch__) \
-    || defined (__riscv)
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   unsigned long offset:56;
   unsigned int size:8;
 #else
@@ -137,12 +132,12 @@ typedef struct
   unsigned long offset:56;
 #endif
 #else
-#if __BYTE_ORDER == __BIG_ENDIAN
-  unsigned int size:8;
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   unsigned int offset:24;
+  unsigned int size:8;
 #else
-  unsigned int offset:24;
   unsigned int size:8;
+  unsigned int offset:24;
 #endif
 #endif
 } logNodeType;


### PR DESCRIPTION
SPHDE has to know the pointer word size and platform Endian. This was simple for 1st two platforms (PowerPC and X86) but got to be a bit of a cludge as more platforms are added. So want sasconf.h to establish __WORDSIZE__64/32 and let the compiler provide the target Endian:
 - (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 - (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)

 Everywhere else use these defines to size and order bit fields.

 	* src/sasanchr.h (regionFlags[__WORDSIZE_64, __BYTE_ORDER__]): Endian and wordsize adjustments for bit fields.
 	* src/sassim.cpp (logNodeType[__WORDSIZE_64, __BYTE_ORDER__]): Endian and wordsize adjustments for bit fields.

 	*src/sasconf.h [__LP64__]: If not already defined,
 	define __WORDSIZE_64/32 from __LP64__.